### PR TITLE
Move to using new clangdev variants

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.5" %}
 {% set sha256 = "ac017e7f48d8f47d5d13815b77f5c555769f3a5e2c3cae8ba5bf4ea34e39923a" %}
 {% set build_number = 1004 %}
-{% set clang_version = "5.0.0" %}
+{% set clang_version = [5, 0, 0] %}
 {% set clang_patches_version = "6.14.06" %}
 
 package:
@@ -63,8 +63,8 @@ requirements:
     - ninja  # [win]
     - {{ compiler('cxx') }}
   host:
-    - llvmdev=5
-    - clangdev={{ clang_version }}
+    - llvmdev={{ clang_version[0] }}
+    - clangdev={{ clang_version|join('.') }}
     - clang_variant * cling_{{ clang_patches_version }}
     - zlib
   run:
@@ -72,7 +72,7 @@ requirements:
     #  - the host compiler STL is one to be used.
     #  - it is used by cling's runtime compatibility check.
     - {{ compiler('cxx') }}  # [linux]
-    - clangdev={{ clang_version }}
+    - clangdev={{ clang_version|join('.') }}
     - clang_variant * cling_{{ clang_patches_version }}
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,9 @@
 {% set name = "cling" %}
 {% set version = "0.5" %}
 {% set sha256 = "ac017e7f48d8f47d5d13815b77f5c555769f3a5e2c3cae8ba5bf4ea34e39923a" %}
-{% set build_number = 1003 %}
+{% set build_number = 1004 %}
 {% set clang_version = "5.0.0" %}
+{% set clang_patches_version = "6.14.06" %}
 
 package:
   name: {{ name|lower }}
@@ -62,8 +63,9 @@ requirements:
     - ninja  # [win]
     - {{ compiler('cxx') }}
   host:
+    - llvmdev=5
     - clangdev={{ clang_version }}
-    - clang_variant * cling
+    - clang_variant * cling_{{ clang_patches_version }}
     - zlib
   run:
     # We really depend on the host compiler at runtime:
@@ -71,7 +73,7 @@ requirements:
     #  - it is used by cling's runtime compatibility check.
     - {{ compiler('cxx') }}  # [linux]
     - clangdev={{ clang_version }}
-    - clang_variant * cling
+    - clang_variant * cling_{{ clang_patches_version }}
 
 test:
   commands:


### PR DESCRIPTION
This should fix the sysroot issues described in #18.

@conda-forge-admin, please rerender