### PR TITLE
Depend on libcxx on macOS

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "cling" %}
 {% set version = "0.5" %}
 {% set sha256 = "ac017e7f48d8f47d5d13815b77f5c555769f3a5e2c3cae8ba5bf4ea34e39923a" %}
-{% set build_number = 1005 %}
+{% set build_number = 1006 %}
 {% set clang_version = [5, 0, 0] %}
 {% set clang_patches_version = "6.14.06" %}
 
@@ -72,6 +72,8 @@ requirements:
     #  - the host compiler STL is one to be used.
     #  - it is used by cling's runtime compatibility check.
     - {{ compiler('cxx') }}  # [linux]
+    # TODO: This should match the build version instead of being fixed
+    - libcxx=4  # [osx]
     - clangdev={{ clang_version|join('.') }}
     - clang_variant * cling_{{ clang_patches_version }}
 


### PR DESCRIPTION
See https://github.com/conda-forge/cling-feedstock/pull/24#issuecomment-459636713 for details.

cc @SylvainCorlay 