### PR TITLE
Bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "cling" %}
 {% set version = "0.7" %}
 {% set sha256 = "cb72186edd8b1ccc0662542c70b02725891e2405aecd5631066972e421b51259" %}
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 {% set clang_version = [5, 0, 0] %}
 
 package:


### PR DESCRIPTION
We miss a build number bump when we upgraded to the latest compilers.